### PR TITLE
Typo/word choice: Audibility -> Auditability

### DIFF
--- a/src/when-to-use.md
+++ b/src/when-to-use.md
@@ -8,7 +8,7 @@
 - **High interoperability requirements**. When multiple groups of people have to use the same schema, Atomic Data provides easy ways to constrain and validate the data and ensure type safety.
 - **Multi-class / multi-model**. Contrary to (SQL) tables, Atomic Data allows a single thing to have multiple classes, each with their own properties.
 - **Connected / decentralized data**. With Atomic Data, you use URLs to point to things on other computers. This makes it possible to connect datasets very explicitly, without creating copies. Very useful for decentralized social networks, for example.
-- **Audibility & Versioning**. Using Atomic Commits, we can store all changes to data as transactions that can be replayed. This creates a complete audit log and history.
+- **Auditability & Versioning**. Using Atomic Commits, we can store all changes to data as transactions that can be replayed. This creates a complete audit log and history.
 - **JSON or RDF as Output**. Atomic Data serializes to idiomatic, clean JSON as well as various RDF formats (Turtle / JSON-LD / n-triples / RDF/XML).
 
 ## When not to use Atomic Data


### PR DESCRIPTION
One more docs PR while I'm in here. I think wasn't quite the right word: "[audibility](https://en.wiktionary.org/wiki/audibility)" is the ability to be heard, while "[auditability](https://en.wiktionary.org/wiki/auditability)" is the ability to be audited. My spell-check doesn't like "auditability", so I'm guessing this was a spell-check mistake, but [it appears to be a real and used word](https://www.google.com/search?hl=en&q=auditability), so I think it just hasn't made it into the word lists yet.